### PR TITLE
Fix average return aggregation for short trades

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
@@ -237,15 +237,10 @@ public class TradeCategory
             Money totalEntryValue = weightedTrades.stream()
                             .map(wt -> wt.trade.getEntryValue().multiplyAndRound(wt.weight))
                             .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-            Money totalExitValue = weightedTrades.stream()
-                            .map(wt -> wt.trade.getExitValue().multiplyAndRound(wt.weight))
-                            .collect(MoneyCollectors.sum(converter.getTermCurrency()));
-            
-            if (totalEntryValue.getAmount() > 0)
+
+            if (totalEntryValue.getAmount() != 0)
             {
-                // For long trades: (exit / entry) - 1
-                // This assumes all trades in category are long (standard case)
-                this.averageReturn = (totalExitValue.getAmount() / (double) totalEntryValue.getAmount()) - 1;
+                this.averageReturn = totalProfitLoss.getAmount() / (double) totalEntryValue.getAmount();
             }
             else
             {


### PR DESCRIPTION
## Summary
- compute trade category average return from aggregated profit/loss so both long and short trades report correctly
- add a regression test that exercises a profitable short trade and verifies the category average return matches the trade return

## Testing
- mvn -pl . test -Dtest=TradeCategoryTest *(fails: Tycho build needs Tycho plugins that are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a6724dfc83249c5a95e4d87b2220