### PR TITLE
Include child taxonomy categories in trade grouping

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
@@ -86,16 +86,16 @@ public class TradesGroupedByTaxonomy
         });
 
         // collect all categories
-        for (Classification classification : taxonomy.getRoot().getChildren())
+        for (TradeCategory category : classificationToCategory.values())
         {
-            TradeCategory category = classificationToCategory.get(classification);
-            if (category != null && category.getTotalWeight() > 0)
+            if (category.getTotalWeight() > 0)
                 categories.add(category);
         }
 
-        // sort by classification rank
-        Collections.sort(categories,
-                        Comparator.comparingInt(c -> c.getClassification().getRank()));
+        // sort by classification rank (and id as tie-breaker for deterministic order)
+        Collections.sort(categories, Comparator
+                        .comparingInt((TradeCategory c) -> c.getClassification().getRank())
+                        .thenComparing(c -> c.getClassification().getId()));
 
         // handle unassigned trades
         createUnassignedCategory(tradeAssignedWeights);


### PR DESCRIPTION
## Summary
- include every non-root classification when building grouped trade categories
- maintain deterministic taxonomy ordering by sorting with rank and id tie-breaker
- add a regression test covering parent and child taxonomy classifications

## Testing
- `mvn -Dtest=TradesGroupedByTaxonomyTest test` *(fails: requires org.eclipse.tycho:tycho-maven-plugin which is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ad6a628483249c9c0212114daa7f