### PR TITLE
Add totals rows to trades view

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeElement.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/trades/TradeElement.java
@@ -5,6 +5,7 @@ import name.abuchen.portfolio.model.Adaptor;
 import name.abuchen.portfolio.model.Classification;
 import name.abuchen.portfolio.snapshot.trades.Trade;
 import name.abuchen.portfolio.snapshot.trades.TradeCategory;
+import name.abuchen.portfolio.snapshot.trades.TradeTotals;
 
 /**
  * Wrapper element for displaying trades in a flat table with taxonomy
@@ -15,6 +16,7 @@ public class TradeElement implements Adaptable
 {
     private final TradeCategory category;
     private final Trade trade;
+    private final TradeTotals totals;
     private final int sortOrder;
 
     /**
@@ -24,6 +26,7 @@ public class TradeElement implements Adaptable
     {
         this.category = category;
         this.trade = null;
+        this.totals = null;
         this.sortOrder = sortOrder;
     }
 
@@ -34,6 +37,18 @@ public class TradeElement implements Adaptable
     {
         this.category = null;
         this.trade = trade;
+        this.totals = null;
+        this.sortOrder = sortOrder;
+    }
+
+    /**
+     * Creates a totals element
+     */
+    public TradeElement(TradeTotals totals, int sortOrder)
+    {
+        this.category = null;
+        this.trade = null;
+        this.totals = totals;
         this.sortOrder = sortOrder;
     }
 
@@ -47,6 +62,11 @@ public class TradeElement implements Adaptable
         return trade != null;
     }
 
+    public boolean isTotal()
+    {
+        return totals != null;
+    }
+
     public TradeCategory getCategory()
     {
         return category;
@@ -55,6 +75,11 @@ public class TradeElement implements Adaptable
     public Trade getTrade()
     {
         return trade;
+    }
+
+    public TradeTotals getTotals()
+    {
+        return totals;
     }
 
     public Classification getClassification()
@@ -72,6 +97,9 @@ public class TradeElement implements Adaptable
     {
         if (category != null && type.isAssignableFrom(category.getClass()))
             return type.cast(category);
+
+        if (totals != null && type.isAssignableFrom(totals.getClass()))
+            return type.cast(totals);
 
         return Adaptor.adapt(type, trade);
     }

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeTotals.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeTotals.java
@@ -1,0 +1,158 @@
+package name.abuchen.portfolio.snapshot.trades;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import name.abuchen.portfolio.model.Classification;
+import name.abuchen.portfolio.money.CurrencyConverter;
+import name.abuchen.portfolio.money.Money;
+import name.abuchen.portfolio.money.MoneyCollectors;
+import name.abuchen.portfolio.money.Values;
+
+public class TradeTotals
+{
+    private final CurrencyConverter converter;
+    private final List<Trade> trades;
+    private final TradeCategory aggregate;
+
+    private final Money totalEntryValue;
+    private final Money totalEntryValueMovingAverage;
+    private final Money totalExitValue;
+    private final Money totalProfitLossMovingAverage;
+    private final Money totalProfitLossMovingAverageWithoutTaxesAndFees;
+    private final long totalShares;
+
+    public TradeTotals(TradesGroupedByTaxonomy groupedTrades)
+    {
+        this.converter = groupedTrades.getCurrencyConverter();
+        this.trades = groupedTrades.getTrades();
+
+        Classification classification = new Classification(null, TradeTotals.class.getName(), "Totals"); //$NON-NLS-1$
+        this.aggregate = new TradeCategory(classification, converter);
+        this.trades.stream().distinct().forEach(trade -> aggregate.addTrade(trade, 1.0));
+
+        this.totalShares = trades.stream().mapToLong(Trade::getShares).sum();
+        this.totalEntryValue = sumMoney(Trade::getEntryValue, Trade::getStart);
+        this.totalEntryValueMovingAverage = sumMoney(Trade::getEntryValueMovingAverage, Trade::getStart);
+        this.totalExitValue = sumMoney(Trade::getExitValue, trade -> trade.getEnd().orElse(LocalDateTime.now()));
+        this.totalProfitLossMovingAverage = sumMoney(Trade::getProfitLossMovingAverage,
+                        trade -> trade.getEnd().orElse(LocalDateTime.now()));
+        this.totalProfitLossMovingAverageWithoutTaxesAndFees = sumMoney(
+                        Trade::getProfitLossMovingAverageWithoutTaxesAndFees,
+                        trade -> trade.getEnd().orElse(LocalDateTime.now()));
+    }
+
+    private Money sumMoney(Function<Trade, Money> extractor, Function<Trade, LocalDateTime> dateExtractor)
+    {
+        return trades.stream()
+                        .map(trade -> {
+                            Money value = extractor.apply(trade);
+                            if (value == null)
+                                return Money.of(converter.getTermCurrency(), 0);
+
+                            LocalDateTime date = Objects.requireNonNullElseGet(dateExtractor.apply(trade),
+                                            LocalDateTime::now);
+                            return value.with(converter.at(date));
+                        })
+                        .collect(MoneyCollectors.sum(converter.getTermCurrency()));
+    }
+
+    public String getCurrencyCode()
+    {
+        return converter.getTermCurrency();
+    }
+
+    public long getTradeCount()
+    {
+        return aggregate.getTradeCount();
+    }
+
+    public long getTotalShares()
+    {
+        return totalShares;
+    }
+
+    public Money getTotalEntryValue()
+    {
+        return totalEntryValue;
+    }
+
+    public Money getTotalEntryValueMovingAverage()
+    {
+        return totalEntryValueMovingAverage;
+    }
+
+    public Money getTotalExitValue()
+    {
+        return totalExitValue;
+    }
+
+    public Money getTotalProfitLoss()
+    {
+        return aggregate.getTotalProfitLoss();
+    }
+
+    public Money getTotalProfitLossWithoutTaxesAndFees()
+    {
+        return aggregate.getTotalProfitLossWithoutTaxesAndFees();
+    }
+
+    public Money getTotalProfitLossMovingAverage()
+    {
+        return totalProfitLossMovingAverage;
+    }
+
+    public Money getTotalProfitLossMovingAverageWithoutTaxesAndFees()
+    {
+        return totalProfitLossMovingAverageWithoutTaxesAndFees;
+    }
+
+    public long getAverageHoldingPeriod()
+    {
+        return aggregate.getAverageHoldingPeriod();
+    }
+
+    public double getAverageIRR()
+    {
+        return aggregate.getAverageIRR();
+    }
+
+    public double getAverageReturn()
+    {
+        return aggregate.getAverageReturn();
+    }
+
+    public double getAverageReturnMovingAverage()
+    {
+        if (totalEntryValueMovingAverage.isZero())
+            return 0;
+        return totalProfitLossMovingAverage.getAmount() / (double) totalEntryValueMovingAverage.getAmount();
+    }
+
+    public Money getAverageEntryPrice()
+    {
+        if (totalShares == 0)
+            return null;
+        long amount = Math.round(totalEntryValue.getAmount() / (double) totalShares * Values.Share.factor());
+        return Money.of(totalEntryValue.getCurrencyCode(), amount);
+    }
+
+    public Money getAverageEntryPriceMovingAverage()
+    {
+        if (totalShares == 0)
+            return null;
+        long amount = Math.round(
+                        totalEntryValueMovingAverage.getAmount() / (double) totalShares * Values.Share.factor());
+        return Money.of(totalEntryValueMovingAverage.getCurrencyCode(), amount);
+    }
+
+    public Money getAverageExitPrice()
+    {
+        if (totalShares == 0)
+            return null;
+        long amount = Math.round(totalExitValue.getAmount() / (double) totalShares * Values.Share.factor());
+        return Money.of(totalExitValue.getCurrencyCode(), amount);
+    }
+}

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradesGroupedByTaxonomy.java
@@ -164,6 +164,11 @@ public class TradesGroupedByTaxonomy
         return Collections.unmodifiableList(categories);
     }
 
+    public List<Trade> getTrades()
+    {
+        return Collections.unmodifiableList(allTrades);
+    }
+
     public Money getTotalProfitLoss()
     {
         return categories.stream().map(TradeCategory::getTotalProfitLoss)


### PR DESCRIPTION
## Summary
- introduce a TradeTotals snapshot helper and expose grouped trade lists so totals can be derived once for a taxonomy
- extend the trade details view to insert configurable sum rows and keep filters/selection working with the new element type
- surface aggregated totals across the trades table columns so grouped views display sum metrics alongside categories

## Testing
- not run (UI changes only)

------
https://chatgpt.com/codex/tasks/task_e_68e2a02f39fc8324a48076f949c9a0a3