### PR TITLE
Handle zero share moving average cost for closed trades

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeTest.java
@@ -131,6 +131,27 @@ public class TradeTest
     }
 
     @Test
+    public void testShortMovingAverageCostDoesNotDivideByZero() throws TradeCollectorException
+    {
+        Client client = new Client();
+        TradeCollector collector = new TradeCollector(client, new TestCurrencyConverter());
+
+        var portfolio = new PortfolioBuilder();
+        portfolio.addTo(client);
+
+        Security securityShort = new SecurityBuilder().addTo(client);
+        portfolio.sellPrice(securityShort, "2024-01-01", 3.0, 20.0)
+                 .buyPrice(securityShort, "2024-12-31", 3.0, 5.0);
+
+        List<Trade> trades = collector.collect(securityShort);
+        Trade trade = trades.get(0);
+
+        Money movingAverageEntryValue = trade.getEntryValueMovingAverage();
+
+        assertThat(movingAverageEntryValue, is(Money.of(CurrencyUnit.EUR, 0L)));
+    }
+
+    @Test
     public void testLongMultipleBuys() throws TradeCollectorException
     {
         Client client = new Client();

--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/Trade.java
@@ -386,6 +386,9 @@ public class Trade implements Adaptable
                         : r.get().getMovingAverageCostWithoutTaxesAndFees().get();
         var totalShares = r.get().getSharesHeld().get();
 
+        if (totalShares <= 0)
+            return Money.of(totalCosts.getCurrencyCode(), 0);
+
         var cost = BigDecimal.valueOf(shares / (double) totalShares) //
                         .multiply(BigDecimal.valueOf(totalCosts.getAmount())) //
                         .setScale(0, RoundingMode.HALF_DOWN).longValue();


### PR DESCRIPTION
## Summary
- guard moving average cost calculations against zero or negative share counts
- add a regression test covering closed short trades to ensure moving average costs do not divide by zero

## Testing
- `mvn -f portfolio-app/pom.xml -pl name.abuchen.portfolio.tests -am -P local-dev test` *(fails: requires downloading Tycho build extensions which is blocked in the sandbox environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ad136ca48324bed47b3a0957133e