### PR TITLE
Sort trade category cash flows before IRR calculation

### DIFF
--- a/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
+++ b/name.abuchen.portfolio/src/name/abuchen/portfolio/snapshot/trades/TradeCategory.java
@@ -38,6 +38,20 @@ public class TradeCategory
         }
     }
 
+    private static final class WeightedCashFlow
+    {
+        private final LocalDate date;
+        private final double amount;
+        private final int order;
+
+        private WeightedCashFlow(LocalDate date, double amount, int order)
+        {
+            this.date = date;
+            this.amount = amount;
+            this.order = order;
+        }
+    }
+
     private final Classification classification;
     private final CurrencyConverter converter;
     private final List<WeightedTrade> weightedTrades = new ArrayList<>();
@@ -158,8 +172,8 @@ public class TradeCategory
      */
     private double calculateCategoryIRR()
     {
-        List<LocalDate> dates = new ArrayList<>();
-        List<Double> values = new ArrayList<>();
+        List<WeightedCashFlow> cashflows = new ArrayList<>();
+        int sequence = 0;
 
         for (WeightedTrade wt : weightedTrades)
         {
@@ -170,8 +184,7 @@ public class TradeCategory
             // Collect cash flows from all transactions in this trade
             double[] collateral = {0};
             trade.getTransactions().forEach(txPair -> {
-                dates.add(txPair.getTransaction().getDateTime().toLocalDate());
-
+                LocalDate date = txPair.getTransaction().getDateTime().toLocalDate();
                 double amount = txPair.getTransaction().getMonetaryAmount()
                                 .with(converter.at(txPair.getTransaction().getDateTime())).getAmount()
                                 / Values.Amount.divider();
@@ -191,32 +204,42 @@ public class TradeCategory
                     amount = collateral[0] - amount;
                 }
 
-                values.add(amount);
+                cashflows.add(new WeightedCashFlow(date, amount, sequence++));
             });
 
             // If trade is still open, add current market value as final cash flow
             if (!trade.isClosed())
             {
-                dates.add(LocalDate.now());
+                LocalDate date = LocalDate.now();
                 double amount = trade.getExitValue().getAmount() / Values.Amount.divider();
                 amount *= weight;
                 if (!isLong)
                     amount = collateral[0] - amount;
-                values.add(amount);
+                cashflows.add(new WeightedCashFlow(date, amount, sequence++));
             }
 
             // For short trades, add final collateral return
             if (!isLong)
             {
                 LocalDate endDate = trade.isClosed() ? trade.getEnd().get().toLocalDate() : LocalDate.now();
-                dates.add(endDate);
-                values.add(collateral[0]);
+                cashflows.add(new WeightedCashFlow(endDate, collateral[0], sequence++));
             }
         }
 
         // If we have no cash flows, return 0
-        if (dates.isEmpty() || values.isEmpty())
+        if (cashflows.isEmpty())
             return 0;
+
+        cashflows.sort(Comparator.comparing((WeightedCashFlow cf) -> cf.date).thenComparingInt(cf -> cf.order));
+
+        List<LocalDate> dates = new ArrayList<>(cashflows.size());
+        List<Double> values = new ArrayList<>(cashflows.size());
+
+        for (WeightedCashFlow cashflow : cashflows)
+        {
+            dates.add(cashflow.date);
+            values.add(cashflow.amount);
+        }
 
         // Calculate IRR from combined cash flows
         double irr = IRR.calculate(dates, values);


### PR DESCRIPTION
## Summary
- sort weighted cash flows by date before invoking the category-level IRR solver so the earliest cash flow is the baseline
- rebuild the IRR input arrays from the ordered data while preserving intra-day ordering of cash flows
- add a regression test that assembles trades with out-of-order closing dates and verifies the aggregated IRR stays positive when profits are positive

## Testing
- mvn -f name.abuchen.portfolio.tests/pom.xml test *(fails: Tycho build extension requires network access to resolve org.eclipse.tycho:tycho-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68e2bbcafaa48324865275c315bdf11c