### PR TITLE
Add moving average trade category aggregations

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
@@ -2,6 +2,7 @@ package name.abuchen.portfolio.snapshot.trades;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
 
 import org.junit.Test;
 
@@ -63,8 +64,13 @@ public class TradeCategoryTest
         // verify aggregations
         assertThat(category.getTradeCount(), is(1L));
         assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(category.getTotalProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
+        assertThat(category.getTotalProfitLossMovingAverageWithoutTaxesAndFees(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
         assertThat(category.getWinningTradesCount(), is(1L));
         assertThat(category.getLosingTradesCount(), is(0L));
+        assertThat(category.getAverageReturnMovingAverage(), is(closeTo(0.1, 1e-10)));
     }
 
     @Test
@@ -103,6 +109,11 @@ public class TradeCategoryTest
 
         // verify weighted aggregations - profit should be 50% of 1000 = 500
         assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(category.getTotalProfitLossMovingAverage(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(category.getTotalProfitLossMovingAverageWithoutTaxesAndFees(),
+                        is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
+        assertThat(category.getAverageReturnMovingAverage(), is(closeTo(0.1, 1e-10)));
     }
 
     @Test

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -585,7 +585,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(element);
             if (totals != null)
                 return totals.getTotalProfitLossMovingAverage();
-            return null;
+            TradeCategory category = asCategory(element);
+            return category != null ? category.getTotalProfitLossMovingAverage() : null;
         }, view.getClient()));
         column.setSorter(ColumnViewerSorter.create(e -> {
             Trade trade = asTrade(e);
@@ -594,7 +595,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(e);
             if (totals != null)
                 return totals.getTotalProfitLossMovingAverage();
-            return null;
+            TradeCategory category = asCategory(e);
+            return category != null ? category.getTotalProfitLossMovingAverage() : null;
         }));
         column.setVisible(false);
         support.addColumn(column);
@@ -611,7 +613,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(element);
             if (totals != null)
                 return totals.getTotalProfitLossMovingAverageWithoutTaxesAndFees();
-            return null;
+            TradeCategory category = asCategory(element);
+            return category != null ? category.getTotalProfitLossMovingAverageWithoutTaxesAndFees() : null;
         }, view.getClient()));
         column.setSorter(ColumnViewerSorter.create(e -> {
             Trade trade = asTrade(e);
@@ -620,7 +623,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(e);
             if (totals != null)
                 return totals.getTotalProfitLossMovingAverageWithoutTaxesAndFees();
-            return null;
+            TradeCategory category = asCategory(e);
+            return category != null ? category.getTotalProfitLossMovingAverageWithoutTaxesAndFees() : null;
         }));
         column.setVisible(false);
         support.addColumn(column);
@@ -727,7 +731,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(element);
             if (totals != null)
                 return totals.getAverageReturnMovingAverage();
-            return null;
+            TradeCategory category = asCategory(element);
+            return category != null ? category.getAverageReturnMovingAverage() : null;
         }));
         column.setSorter(ColumnViewerSorter.create(e -> {
             Trade trade = asTrade(e);
@@ -736,7 +741,8 @@ public class TradesTableViewer
             TradeTotals totals = asTotals(e);
             if (totals != null)
                 return totals.getAverageReturnMovingAverage();
-            return null;
+            TradeCategory category = asCategory(e);
+            return category != null ? category.getAverageReturnMovingAverage() : null;
         }));
         column.setVisible(false);
         support.addColumn(column);


### PR DESCRIPTION
## Summary
- extend `TradeCategory` with moving-average profit and return aggregates derived from weighted trades
- expose the new moving-average values in the trades table when displaying grouped categories
- expand `TradeCategoryTest` to verify the new moving-average aggregation calculations

## Testing
- `mvn -f portfolio-app/pom.xml -pl name.abuchen.portfolio.tests test -Dtest=TradeCategoryTest` *(fails: unable to resolve org.eclipse.tycho:tycho-maven-plugin:5.0.0 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dc02fb648324a3614b3c8d29dc6f