### PR TITLE
Populate category entry and exit values in trades view

### DIFF
--- a/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
+++ b/name.abuchen.portfolio.tests/src/name/abuchen/portfolio/snapshot/trades/TradeCategoryTest.java
@@ -63,6 +63,8 @@ public class TradeCategoryTest
 
         // verify aggregations
         assertThat(category.getTradeCount(), is(1L));
+        assertThat(category.getTotalEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(10000))));
+        assertThat(category.getTotalExitValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(11000))));
         assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
         assertThat(category.getTotalProfitLossMovingAverage(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(1000))));
@@ -108,6 +110,8 @@ public class TradeCategoryTest
         category.addTrade(trades.get(0), 0.5);
 
         // verify weighted aggregations - profit should be 50% of 1000 = 500
+        assertThat(category.getTotalEntryValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5000))));
+        assertThat(category.getTotalExitValue(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(5500))));
         assertThat(category.getTotalProfitLoss(), is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));
         assertThat(category.getTotalProfitLossMovingAverage(),
                         is(Money.of(CurrencyUnit.EUR, Values.Amount.factorize(500))));

--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -356,21 +356,27 @@ public class TradesTableViewer
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
-            public String getText(Object e)
-            {
-                Trade trade = asTrade(e);
-                if (trade != null)
-                    return Values.Money.format(trade.getEntryValue(), view.getClient().getBaseCurrency());
-                TradeTotals totals = asTotals(e);
-                if (totals != null)
-                    return Values.Money.format(totals.getTotalEntryValue(), view.getClient().getBaseCurrency());
-                return null;
-            }
-        });
+                public String getText(Object e)
+                {
+                    Trade trade = asTrade(e);
+                    if (trade != null)
+                        return Values.Money.format(trade.getEntryValue(), view.getClient().getBaseCurrency());
+                    TradeCategory category = asCategory(e);
+                    if (category != null)
+                        return Values.Money.format(category.getTotalEntryValue(), view.getClient().getBaseCurrency());
+                    TradeTotals totals = asTotals(e);
+                    if (totals != null)
+                        return Values.Money.format(totals.getTotalEntryValue(), view.getClient().getBaseCurrency());
+                    return null;
+                }
+            });
         column.setSorter(ColumnViewerSorter.create(e -> {
             Trade trade = asTrade(e);
             if (trade != null)
                 return trade.getEntryValue();
+            TradeCategory category = asCategory(e);
+            if (category != null)
+                return category.getTotalEntryValue();
             TradeTotals totals = asTotals(e);
             if (totals != null)
                 return totals.getTotalEntryValue();
@@ -473,21 +479,27 @@ public class TradesTableViewer
         column.setLabelProvider(new ColumnLabelProvider()
         {
             @Override
-            public String getText(Object e)
-            {
-                Trade trade = asTrade(e);
-                if (trade != null)
-                    return Values.Money.format(trade.getExitValue(), view.getClient().getBaseCurrency());
-                TradeTotals totals = asTotals(e);
-                if (totals != null)
-                    return Values.Money.format(totals.getTotalExitValue(), view.getClient().getBaseCurrency());
-                return null;
-            }
-        });
+                public String getText(Object e)
+                {
+                    Trade trade = asTrade(e);
+                    if (trade != null)
+                        return Values.Money.format(trade.getExitValue(), view.getClient().getBaseCurrency());
+                    TradeCategory category = asCategory(e);
+                    if (category != null)
+                        return Values.Money.format(category.getTotalExitValue(), view.getClient().getBaseCurrency());
+                    TradeTotals totals = asTotals(e);
+                    if (totals != null)
+                        return Values.Money.format(totals.getTotalExitValue(), view.getClient().getBaseCurrency());
+                    return null;
+                }
+            });
         column.setSorter(ColumnViewerSorter.create(e -> {
             Trade trade = asTrade(e);
             if (trade != null)
                 return trade.getExitValue();
+            TradeCategory category = asCategory(e);
+            if (category != null)
+                return category.getTotalExitValue();
             TradeTotals totals = asTotals(e);
             if (totals != null)
                 return totals.getTotalExitValue();


### PR DESCRIPTION
## Summary
- compute and expose aggregate entry and exit values for grouped trade categories
- display the aggregated entry and exit totals for category rows in the Trades view
- extend TradeCategory tests to cover the new entry and exit value aggregations

## Testing
- `mvn -f name.abuchen.portfolio.tests/pom.xml -Dtest=TradeCategoryTest test` *(fails: Tycho plugin org.eclipse.tycho:tycho-maven-plugin:5.0.0 cannot be resolved in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dfc2973883248998a84e6ea8524f