### PR TITLE
Populate moving average entry values in Trades view summary rows

### DIFF
--- a/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
+++ b/name.abuchen.portfolio.ui/src/name/abuchen/portfolio/ui/views/TradesTableViewer.java
@@ -397,6 +397,14 @@ public class TradesTableViewer
                 Trade trade = asTrade(e);
                 if (trade != null)
                     return Values.Money.format(trade.getEntryValueMovingAverage(), view.getClient().getBaseCurrency());
+                TradeCategory category = asCategory(e);
+                if (category != null)
+                    return Values.Money.format(category.getTotalEntryValueMovingAverage(),
+                                    view.getClient().getBaseCurrency());
+                TradeTotals totals = asTotals(e);
+                if (totals != null)
+                    return Values.Money.format(totals.getTotalEntryValueMovingAverage(),
+                                    view.getClient().getBaseCurrency());
                 return null;
             }
         });
@@ -404,6 +412,12 @@ public class TradesTableViewer
             Trade trade = asTrade(e);
             if (trade != null)
                 return trade.getEntryValueMovingAverage();
+            TradeCategory category = asCategory(e);
+            if (category != null)
+                return category.getTotalEntryValueMovingAverage();
+            TradeTotals totals = asTotals(e);
+            if (totals != null)
+                return totals.getTotalEntryValueMovingAverage();
             return null;
         }));
         column.setVisible(false);


### PR DESCRIPTION
## Summary
- show moving average entry value in category and totals rows in the Trades view
- ensure the column sorter handles category and totals rows using the aggregated moving average values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2e2fa17948324a005c092ad91f6f8