### PR TITLE
Add NoDetach tag to portfolio part descriptor

### DIFF
--- a/name.abuchen.portfolio.bootstrap/Application.e4xmi
+++ b/name.abuchen.portfolio.bootstrap/Application.e4xmi
@@ -260,6 +260,7 @@
     <tags>removeOnHide</tags>
     <tags>Editor</tags>
     <tags>Cloneable</tags>
+    <tags>NoDetach</tags>
   </descriptors>
   <descriptors xmi:id="_4RiCMKz9EeOjzfbCEdp40A" elementId="name.abuchen.portfolio.ui.part.textviewer" label="%part.textviewer" allowMultiple="true" closeable="true" contributionURI="bundleclass://name.abuchen.portfolio.ui/name.abuchen.portfolio.ui.parts.TextViewerPart"/>
   <commands xmi:id="_1mco0Bi8EeO8gYEHAOvLsA" elementId="org.eclipse.ui.file.exit" commandName="quitCommand"/>


### PR DESCRIPTION
### Motivation
- The portfolio editor should not be detachable from the main window, so add a `NoDetach` tag to its descriptor in `Application.e4xmi`.

### Description
- Add `<tags>NoDetach</tags>` to the `name.abuchen.portfolio.ui.part.portfolio` descriptor in `name.abuchen.portfolio.bootstrap/Application.e4xmi` to prevent detaching the portfolio part.

### Testing
- Ran the project build and existing automated test suite including UI startup smoke tests; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc439bfbc083248e0bb74f337a6021)